### PR TITLE
Fix odoo-addon workflow lint installation

### DIFF
--- a/.github/workflows/odoo_addon.yml
+++ b/.github/workflows/odoo_addon.yml
@@ -6,9 +6,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - run: pipx install pylint-odoo flake8-odoo
-      - run: pipx run pylint-odoo || true
-      - run: pipx run flake8-odoo || true
+        with:
+          python-version: '3.11'
+      - name: Install linting dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pylint-odoo flake8-odoo
+      - name: Run pylint-odoo
+        run: python -m pylint_odoo || true
+      - name: Run flake8-odoo
+        run: python -m flake8 || true
   package:
     needs: validate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace pipx usage in the odoo-addon validation job with a standard pip install
- pin the Python version used by the workflow and run linters via python -m modules

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_6909b1734f70832288d6874395b9b8f4