### PR TITLE
Add Odoo 18 compliance audit report

### DIFF
--- a/reports/odoo18_audit.json
+++ b/reports/odoo18_audit.json
@@ -1,0 +1,68 @@
+{
+  "summary": {
+    "modules_scanned": 2,
+    "hard_failures": 3,
+    "security_risks": 2,
+    "style_violations": 1,
+    "perf_warnings": 0
+  },
+  "findings": [
+    {
+      "severity": "HIGH",
+      "rule": "PYTHON.MISSING_IMPORT",
+      "file": "addons/ipai_agent/models/agent_api.py",
+      "line": 211,
+      "message": "AccessError is raised but not imported, so hitting the permission gate triggers a NameError and blocks agent actions.",
+      "evidence": "_check_action_permission() raises AccessError while the module only imports UserError.",
+      "fix": "Import AccessError from odoo.exceptions alongside UserError.",
+      "autofix_diff": "--- a/addons/ipai_agent/models/agent_api.py\n+++ b/addons/ipai_agent/models/agent_api.py\n@@\n-import requests\n-from odoo.exceptions import UserError\n+import requests\n+from odoo.exceptions import AccessError, UserError\n"
+    },
+    {
+      "severity": "HIGH",
+      "rule": "SECURITY.SUBPROCESS_UNSANITIZED",
+      "file": "addons/ipai_agent/models/agent_api.py",
+      "line": 248,
+      "message": "Deployment handler builds a subprocess command directly from agent payload, enabling remote command execution when the webhook or agent is compromised.",
+      "evidence": "_action_deploy_service() concatenates service/environment inputs into cmd and runs subprocess.run().",
+      "fix": "Replace direct subprocess invocation with a queued Odoo job that validates the requested service against an allowlist or triggers a secured server action." 
+    },
+    {
+      "severity": "MEDIUM",
+      "rule": "MANIFEST.VERSION_FORMAT",
+      "file": "addons/ipai_agent/__manifest__.py",
+      "line": 4,
+      "message": "Module version must follow 18.0.x.y.z per Odoo 18/OCA guidelines; manifest still declares 1.0.0.",
+      "evidence": "Version key is set to '1.0.0'.",
+      "fix": "Update the version to an 18.0.* semantic version such as 18.0.1.0.0.",
+      "autofix_diff": "--- a/addons/ipai_agent/__manifest__.py\n+++ b/addons/ipai_agent/__manifest__.py\n@@\n-    \"version\": \"1.0.0\",\n+    \"version\": \"18.0.1.0.0\",\n"
+    },
+    {
+      "severity": "HIGH",
+      "rule": "MANIFEST.MISSING_DATA",
+      "file": "addons/ipai_agent_hybrid/__manifest__.py",
+      "line": 54,
+      "message": "Manifest references security/data/view files that are absent, so the module cannot install.",
+      "evidence": "The module directory only contains README, manifest, and models without the declared security or data files.",
+      "fix": "Add the referenced security and data XML/CSV files or drop them from the manifest until they exist."
+    },
+    {
+      "severity": "HIGH",
+      "rule": "MODULE.INIT_IMPORT",
+      "file": "addons/ipai_agent_hybrid/models/__init__.py",
+      "line": 1,
+      "message": "models/__init__.py is empty, so ip_page.py is never imported and the ORM does not register the models.",
+      "evidence": "__init__ contains only the coding header with no imports.",
+      "fix": "Import ip_page inside models/__init__.py so Odoo loads the model class.",
+      "autofix_diff": "--- a/addons/ipai_agent_hybrid/models/__init__.py\n+++ b/addons/ipai_agent_hybrid/models/__init__.py\n@@\n-# -*- coding: utf-8 -*-\n+# -*- coding: utf-8 -*-\n+from . import ip_page\n"
+    },
+    {
+      "severity": "MEDIUM",
+      "rule": "SECURITY.PUBLIC_ENDPOINT",
+      "file": "addons/ipai_agent/controllers/main.py",
+      "line": 19,
+      "message": "Webhook endpoint is exposed with auth='public' and relies solely on a static API key stored in ir.config_parameter, which is weak protection for high-privilege actions.",
+      "evidence": "agent_webhook route declares auth='public' and compares kwargs['api_key'] to a parameter before sudo() actions.",
+      "fix": "Restrict the route to auth='user' with signed tokens or implement a hashed HMAC signature check and rate limiting." 
+    }
+  ]
+}

--- a/reports/odoo18_audit.md
+++ b/reports/odoo18_audit.md
@@ -1,0 +1,57 @@
+# Odoo 18 CE – OCA Compliance Audit
+
+## Executive Summary
+- **Status:** Fail – multiple blocking issues prevent safe installation and operation of custom addons.
+- **Top Risks:**
+  1. `ipai_agent` permission guard raises `AccessError` without importing it, crashing secure workflows.
+  2. `ipai_agent` executes deployment commands via `subprocess.run` with untrusted payload data.
+  3. `ipai_agent_hybrid` manifest references missing security/data files and never imports its own models.
+
+## Findings Overview
+| Severity | File | Rule | Summary | Suggested Fix |
+| --- | --- | --- | --- | --- |
+| HIGH | addons/ipai_agent/models/agent_api.py | PYTHON.MISSING_IMPORT | AccessError raised without import causes NameError when permissions checked. | Import `AccessError` from `odoo.exceptions`. |
+| HIGH | addons/ipai_agent/models/agent_api.py | SECURITY.SUBPROCESS_UNSANITIZED | Deployment handler builds subprocess command from agent input (RCE risk). | Replace with validated server action/queue job and whitelist services. |
+| MEDIUM | addons/ipai_agent/__manifest__.py | MANIFEST.VERSION_FORMAT | Manifest version uses `1.0.0` instead of `18.0.x.y.z`. | Bump to `18.0.1.0.0`. |
+| HIGH | addons/ipai_agent_hybrid/__manifest__.py | MANIFEST.MISSING_DATA | Manifest lists security/data/view files that do not exist. | Add the declared files or remove them until available. |
+| HIGH | addons/ipai_agent_hybrid/models/__init__.py | MODULE.INIT_IMPORT | Models package never imports `ip_page.py`, so ORM skips all models. | Import `ip_page` inside `models/__init__.py`. |
+| MEDIUM | addons/ipai_agent/controllers/main.py | SECURITY.PUBLIC_ENDPOINT | Webhook exposed as `auth='public'` with shared API key and sudo() usage. | Move to `auth='user'` or implement signed HMAC and throttling. |
+
+## Auto-fix Patches
+```diff
+--- a/addons/ipai_agent/models/agent_api.py
++++ b/addons/ipai_agent/models/agent_api.py
+@@
+-import requests
+-from odoo.exceptions import UserError
++import requests
++from odoo.exceptions import AccessError, UserError
+```
+```diff
+--- a/addons/ipai_agent/__manifest__.py
++++ b/addons/ipai_agent/__manifest__.py
+@@
+-    "version": "1.0.0",
++    "version": "18.0.1.0.0",
+```
+```diff
+--- a/addons/ipai_agent_hybrid/models/__init__.py
++++ b/addons/ipai_agent_hybrid/models/__init__.py
+@@
+-# -*- coding: utf-8 -*-
++# -*- coding: utf-8 -*-
++from . import ip_page
+```
+
+## Reviewer Checklist
+- [ ] Implement a secure, queued deployment mechanism instead of direct `subprocess.run` calls and restrict action inputs.
+- [ ] Provide the missing security/data XML/CSV payloads for `ipai_agent_hybrid` or adjust the manifest accordingly.
+- [ ] Add model access rights and record rules for `ipai_agent_hybrid` once files exist, ensuring multi-company isolation.
+- [ ] Harden webhook authentication (signed payloads, rate limiting) before exposing production endpoints.
+- [ ] Add automated tests covering agent permission checks, webhook authentication, and hybrid module CRUD flows.
+
+## PR-Ready Summary
+- Fix agent permission guard by importing `AccessError` and harden deployment execution path.
+- Normalize module metadata to Odoo 18 semantic versioning.
+- Restore missing `ipai_agent_hybrid` assets and load models via `models/__init__.py`; add accompanying security/data records.
+- Harden webhook authentication strategy before production rollout.


### PR DESCRIPTION
## Summary
- add machine-readable Odoo 18/OCA compliance findings
- document the audit conclusions and remediation checklist in Markdown

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cc907c508322904d74c2176b1be7)