### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🚀 InsightPulse Odoo - Enterprise SaaS Replacement Suite
 
+[![Run in Smithery](https://smithery.ai/badge/skills/jgtolentino)](https://smithery.ai/skills?ns=jgtolentino&utm_source=github&utm_medium=badge)
+
+
 [![CI Status](https://github.com/jgtolentino/insightpulse-odoo/workflows/CI/badge.svg)](https://github.com/jgtolentino/insightpulse-odoo/actions)
 [![Deploy Status](https://github.com/jgtolentino/insightpulse-odoo/workflows/Deploy/badge.svg)](https://github.com/jgtolentino/insightpulse-odoo/actions)
 [![Stack Validation](https://github.com/jgtolentino/insightpulse-odoo/workflows/Stack%20Validation/badge.svg)](https://github.com/jgtolentino/insightpulse-odoo/actions)


### PR DESCRIPTION
## Add skill discoverability badge

Your 49 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/jgtolentino)](https://smithery.ai/skills?ns=jgtolentino&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.